### PR TITLE
Add support for a Marionette View widget

### DIFF
--- a/src/support/Widget.coffee
+++ b/src/support/Widget.coffee
@@ -100,6 +100,14 @@ module.exports = ->
     _type: (type) ->
       "[type='#{type}']"
 
+  class @Widget.View extends @Widget
+    ui: (ui)->
+      regions = @regionPath.split(".")
+      viewPath = ("#{region}.currentView" for region in regions).join(".")
+      stmt = "return window.#{@appName}.#{viewPath}.ui.#{ui}.get(0)"
+      @driver.executeScript(stmt)
+
+
   class @Widget.Form extends @Widget.Fields
     submitSelector: ->
       @_type('submit')


### PR DESCRIPTION
this lets you write this:

``` coffee
module.exports = ->
  this.Widgets = this.Widgets || {}

  return this.Widgets.TodoFooter = this.Widget.View.extend
    appName: 'TodoMVC'
    regionPath: 'footer'

    summaryText: ->
      @ui('summary').then (el)-> el.getText()

    filterByCompleted: ->
      @ui('completed').then (el) -> el.click()

    filterByActive: ->
      @ui('active').then (el) -> el.click()
```

It's pretty simple at the moment, but  very powerful.
