### PR TITLE
Introduce Widget clear method

### DIFF
--- a/docs/widget.md
+++ b/docs/widget.md
@@ -35,6 +35,7 @@ All `Widgets` extend from seleniums [WebElement](http://selenium.googlecode.com/
     * [removeClass](#removeclass)
     * [toggleClass](#toggleclass)
     * [hasClass](#hasclass)
+    * [clear](#clear)
   * [Querying the DOM](#querying-the-dom)
     * [Read](#read)
     * [Find](#find)
@@ -251,6 +252,23 @@ var hidden = new Widget.extend({
 `function hasClass({className: name, selector: <selector>})`
 
 `hasClass` will test the existence of the provided class name on the DOM node of the Widget. It takes a hash that can contain an optional selector. If you only pass a string to the method and not an object then it will use the string as the class name. It returns a promise that will resolve with `true` or `false`.
+
+### clear
+
+`function clear({selector: <selector>})`
+
+`clear` will call [clear](http://selenium.googlecode.com/git/docs/api/javascript/source/lib/webdriver/webdriver.js.src.html#l1967) on the element. Takes a hash that supports an optional selector to scope the `clear` operation. If only a string is passed to clear, and not an object then it will use it as a selector for the `find` operation.
+Returns a promise that resolves with the widget once the element has been cleared.
+
+```js
+new this.Widget({
+  root: "#container"
+}).clear({
+  selector: "input"
+}).then(function(widget){
+  ...
+});
+```
 
 ## Querying the DOM
 

--- a/src/widgets/Widget.coffee
+++ b/src/widgets/Widget.coffee
@@ -205,3 +205,8 @@ $       = Driver.promise
       .doubleClick(el)
       .perform()
       .then => this
+
+  clear: (opts) ->
+    @find(opts)
+    .then (el) =>
+      el.clear().then => this

--- a/test/integration/features/widget.feature
+++ b/test/integration/features/widget.feature
@@ -66,3 +66,6 @@ Feature: Manipulating Widgets
 
   Scenario: Doubling clicking an element
     Given I should be able to double click an element
+
+  Scenario: Clearing an input
+    Given I should be able to clear an input

--- a/test/integration/steps/steps.coffee
+++ b/test/integration/steps/steps.coffee
@@ -30,3 +30,11 @@ module.exports = ->
       w.read()
       .should.eventually
       .eql("wow such click")
+
+  @Given /^I should be able to clear an input$/, ->
+    w = new @W({
+      root: ".inputbox"
+    })
+    w.sendKeys("filled with this").then =>
+      w.clear().then (widget) ->
+        widget.getValue().should.eventually.eql("")


### PR DESCRIPTION
Tired of having to do 

``` coffeescript
a = new @W({root: "input"})
a.clear().then =>
   a[method]..........
```

Also nice that it returns widget instead of nothing, because el.clear returns a promise that resolves with nothing
