### PR TITLE
Allow pioneer to be run with cmd line args alone.

### DIFF
--- a/src/config_builder.coffee
+++ b/src/config_builder.coffee
@@ -97,7 +97,7 @@ module.exports =
 
       if (minimist[name]?)
         obj[name] = minimist[name]
-        if name is 'require'
+        if name is 'require' and config[name]?
           obj[name] = Array::concat(obj[name]).concat(config[name])
       else if config[name]?
         obj[name] = config[name]

--- a/test/unit/config.coffee
+++ b/test/unit/config.coffee
@@ -103,6 +103,7 @@ describe "Pioneer configuration", ->
       it "should generate options with just commandline options", ->
         configBuilder.generateOptions({
           driver:"pretty",
+          require: ["that.js", "this.json", "totally.css"]
           feature:"test/integration/features"
         }, {}, this.libPath)
 
@@ -110,6 +111,7 @@ describe "Pioneer configuration", ->
         .should.have.been
         .calledWith([
           {feature: 'test/integration/features'},
+          {require: ["that.js", "this.json", "totally.css"]},
           {driver: "pretty"}
         ])
 


### PR DESCRIPTION
Should fix https://github.com/mojotech/grunt-pioneer/issues/5

``` bash
$ pioneer features --require=steps --require=widgets
```

``` bash
fs.js:684
  return binding.lstat(pathModule._makeLong(path));
                 ^
Error: ENOENT, no such file or directory '/src/project/--require'
    at Object.fs.lstatSync (fs.js:684:18)
    at Object.realpathSync (fs.js:1272:21)
    at Object.expandPathWithRegexp (/src/project/node_modules/pioneer/node_modules/cucumber/lib/cucumber/cli/argument_parser/path_expander.js:17:23)
    at /src/project/node_modules/pioneer/node_modules/cucumber/lib/cucumber/cli/argument_parser/path_expander.js:9:39
    at Array.forEach (native)
    at Object.expandPathsWithRegexp (/src/project/node_modules/pioneer/node_modules/cucumber/lib/cucumber/cli/argument_parser/path_expander.js:8:11)
    at Object.expandPaths (/src/project/node_modules/pioneer/node_modules/cucumber/lib/cucumber/cli/argument_parser/support_code_path_expander.js:7:38)
    at Object.getSupportCodeFilePaths (/src/project/node_modules/pioneer/node_modules/cucumber/lib/cucumber/cli/argument_parser.js:44:83)
    at Object.
```

``` bash
$ echo '{ "require": [ "steps" ] }' > pioneer.json
$ pioneer features --require=widgets
```

Works :thumbsup:  
