### PR TITLE
Bump chai to 1.9.2 to satisfy sinon-chai peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "bluebird": "^1.2.4",
-    "chai": "~1.8.1",
+    "chai": "~1.9.2",
     "chai-as-promised": "~4.1.0",
     "colors": "^0.6.2",
     "cucumber": "joshtombs/cucumber-js#0.3.3ErrorFormatting",


### PR DESCRIPTION
Error while installing dependencies.

```
$ npm install
...
npm ERR! peerinvalid The package chai does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer chai-as-promised@4.1.1 wants chai@>= 1.7.0 < 2
npm ERR! peerinvalid Peer sinon-chai@2.6.0 wants chai@>=1.9.2 <2
...
```

https://github.com/domenic/sinon-chai/commit/9d72b166784384e84e1bad0e60eb16bce53668ed#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R27
