### PR TITLE
Clean up logging

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -66,6 +66,9 @@ Pioneer can generate a scaffold for your first tests automatically using the opt
 }
 ```
 
+## Verbosity
+You can show some extra information about the test run by setting the `--verbose` flag.
+
 ## Version
 
 You can display the current version of Pioneer that you are using by passing the optional `--version` or `-v` command line flag.

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -67,7 +67,7 @@ Pioneer can generate a scaffold for your first tests automatically using the opt
 ```
 
 ## Verbosity
-You can show some extra information about the test run by setting the `--verbose` flag.
+You can show some extra information about the test run by setting the `--verbose` flag. This can be used to override the value in the config file. You will need to use `--verbose=false` to turn off verbosity that has been set in the config file.
 
 ## Version
 

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -63,3 +63,9 @@ If `coffee` is not declared, then it will default to false.
   "coffee": true
 }
 ```
+
+## Verbosity
+
+If `verbose` is set to true, it will show some extra information about the test run. If it is not declared, then it will default to false.
+
+Note: this value can be overridden by the `--verbose` flag on the command line.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,5 +38,5 @@ gulp.task("default", function() {
 });
 
 gulp.task("watch", function() {
-  gulp.watch('src/**/*.coffee', ['default'])
+  gulp.watch('src/**/*', ['default'])
 });

--- a/src/pioneer.coffee
+++ b/src/pioneer.coffee
@@ -25,10 +25,12 @@ class Pioneer
         configPath = p
       else
         configPath = null
-    if(configPath)
-      console.log ('Configuration loaded from ' + configPath + '\n').yellow.inverse
-    else
-      console.log ('No configuration path specified.\n').yellow.inverse
+
+    if args.verbose
+      if configPath
+        console.log ('Configuration loaded from ' + configPath).yellow.inverse
+      else
+        console.log ('No configuration path specified').yellow.inverse
 
     this.getSpecifications(configPath, libPath, args)
 
@@ -47,17 +49,12 @@ class Pioneer
 
   applySpecifications: (obj, libPath, args) ->
     opts = configBuilder.generateOptions(args, obj, libPath)
-
     this.start(opts) if opts
 
   start: (opts) ->
-    timeStart = new Date().getTime()
-
     require('./environment')()
 
     cucumber.Cli(opts).run (success) ->
-      testTime = moment.duration(new Date().getTime() - timeStart)._data
-      console.log "Duration " + "(" + testTime.minutes + "m:" + testTime.seconds + "s:" + testTime.milliseconds + "ms)"
       process.exit(if success then 0 else 1)
 
   parseAndValidateJSON: (config, path) ->

--- a/src/pioneer.coffee
+++ b/src/pioneer.coffee
@@ -26,26 +26,27 @@ class Pioneer
       else
         configPath = null
 
-    if args.verbose
-      if configPath
-        console.log ('Configuration loaded from ' + configPath).yellow.inverse
-      else
-        console.log ('No configuration path specified').yellow.inverse
-
     this.getSpecifications(configPath, libPath, args)
 
   getSpecifications: (path, libPath, args) ->
-    obj = {}
+    configObject = {}
     if(path)
       fs.readFile(path,
         'utf8',
         (err, data) =>
           throw err if(err)
-          object = this.parseAndValidateJSON(data, path)
-          this.applySpecifications(object, libPath, args)
+          configObject = this.parseAndValidateJSON(data, path)
+
+          if @isVerbose(args, configObject)
+            console.log ('Configuration loaded from ' + path).yellow.inverse
+
+          this.applySpecifications(configObject, libPath, args)
       )
     else
-      this.applySpecifications(obj, libPath, args)
+      if @isVerbose(args, configObject)
+        console.log ('No configuration path specified').yellow.inverse
+
+      this.applySpecifications(configObject, libPath, args)
 
   applySpecifications: (obj, libPath, args) ->
     opts = configBuilder.generateOptions(args, obj, libPath)
@@ -65,5 +66,11 @@ class Pioneer
 
   isVersionRequested: (args) ->
     args.version || args.v
+
+  isVerbose: (args, config = {}) ->
+    if args.verbose?
+      return args.verbose and args.verbose isnt "false"
+    else
+      return !!config.verbose
 
 module.exports = Pioneer

--- a/src/pioneerformat.js
+++ b/src/pioneerformat.js
@@ -1,4 +1,6 @@
-var path = require('path')
+var path = require('path');
+var moment = require('moment');
+
 module.exports = function(options, Cucumber) {
   var color            = Cucumber.Util.ConsoleColor;
   var self             = Cucumber.Listener.Formatter(options);
@@ -10,6 +12,11 @@ module.exports = function(options, Cucumber) {
     summaryFormatter.hear(event, function () {
       parentHear(event, callback);
     });
+  };
+
+  self.handleBeforeFeaturesEvent = function (event, callback) {
+    self.timeStart = new Date().getTime();
+    callback();
   };
 
   self.handleBeforeFeatureEvent = function handleBeforeFeatureEvent(event, callback) {
@@ -106,7 +113,10 @@ module.exports = function(options, Cucumber) {
 
   self.handleAfterFeaturesEvent = function handleAfterFeaturesEvent(event, callback) {
     var summaryLogs = summaryFormatter.getLogs();
-    self.log("\n");
+
+    testTime = moment.duration(new Date().getTime() - self.timeStart)._data;
+    self.log("\nDuration " + "(" + testTime.minutes + "m:" + testTime.seconds + "s:" + testTime.milliseconds + "ms)\n");
+
     callback();
   };
 

--- a/src/scaffold/example.json
+++ b/src/scaffold/example.json
@@ -8,5 +8,6 @@
   "driver": "chrome",
   "error_formatter": "errorformat.js",
   "preventReload": false,
-  "coffee": false
+  "coffee": false,
+  "verbose": true
 }

--- a/test/unit/bin.coffee
+++ b/test/unit/bin.coffee
@@ -37,3 +37,40 @@ describe "Pioneer Kickoff File", ->
       currentV = require('../../package').version
       new Pioneer("wow")
       @consoleSpy.should.have.been.calledWith(currentV);
+
+  describe "isVerbose", ->
+
+    describe "when only a command line value is passed", ->
+
+      it "should treat true and 'true' as true", ->
+        Pioneer::isVerbose({verbose: true})
+        .should.be.true
+
+        Pioneer::isVerbose({verbose: "true"})
+        .should.be.true
+
+      it "should treat missing or 'false' value as false", ->
+        Pioneer::isVerbose({verbose: "false"})
+        .should.be.false
+
+        Pioneer::isVerbose({})
+        .should.be.false
+
+    describe "when only a config value is passed", ->
+
+      it "should return true when passed a truthy value", ->
+        Pioneer::isVerbose({}, {verbose: true})
+        .should.be.true
+
+      it "should return false when passed a falsey value", ->
+        Pioneer::isVerbose({}, {verbose: ""})
+        .should.be.false
+
+    describe "when a config and command line value are passed", ->
+
+      it "should defer to the command line value", ->
+        Pioneer::isVerbose({verbose: true}, {verbose: false})
+        .should.be.true
+
+        Pioneer::isVerbose({verbose: false}, {verbose: true})
+        .should.be.false


### PR DESCRIPTION
The test run should not output anything except that which is written by the reporter (e.g. pioneerformat.js, Cucumber JSON reporter, etc.). Currently, pioneer writes some information about the config file as well as test timing, which gets in the way when you want to pipe the result of a reporter into a file, for example.

I've moved the duration reporting inside the pioneerformat file, and only write the config file information when a verbose flag is set.