### PR TITLE
Opt out of update notification

### DIFF
--- a/bin/pioneer
+++ b/bin/pioneer
@@ -5,11 +5,15 @@ var fs          = require('fs');
 var lib         = path.join(path.dirname(fs.realpathSync(__filename)), path.join('../', 'lib'));
 var Pioneer     = require(lib + path.join('/', 'pioneer'));
 
-var updateNotifier = require('update-notifier');
-var notifier = updateNotifier({packagePath: path.join('../', 'package.json')});
+var checkForUpdates = process.argv.indexOf("--noUpdates") === -1
 
-if (notifier.update) {
-    notifier.notify();
+if (checkForUpdates) {
+  var updateNotifier = require('update-notifier');
+  var notifier = updateNotifier({packagePath: path.join('../', 'package.json')});
+
+  if (notifier.update) {
+      notifier.notify();
+  }
 }
 
 global.ARGV = Array.prototype.slice.call(process.argv);


### PR DESCRIPTION
We're starting to run pioneer tests in parallel, and we get errors from ```update-notifier``` in about 50% of runs. I'm guessing that it's doing something globally.

Also, in our CI process, we don't want messages about update notification getting into the output stream when we're piping output for the build server to read. I'm not sure if ```update-notifier``` writes on ```stdout```, so this might not be a problem, but really, we don't care about update notifications in our CI process.

To solve these two problems, we allow a ```--noUpdates``` flag from the command line to simply switch off that check.