### PR TITLE
Cleanup driver commands after scenario

### DIFF
--- a/src/support/index.coffee
+++ b/src/support/index.coffee
@@ -7,7 +7,7 @@ global.timeout  = 5000
 
 module.exports = ->
   @Driver = Driver
-  
+
   _Before = @Before
   _After  = @After
 
@@ -42,7 +42,7 @@ module.exports = ->
     .createFlow (flow) =>
       flow.execute =>
         code.apply(@, args)
-    .then (result) -> 
+    .then (result) ->
       successCallback null, result
     , errCallback
 
@@ -94,6 +94,9 @@ module.exports = ->
 
   @After ->
     terminateDriver() unless shouldPreventBrowserReload()
+
+  @registerHandler "AfterScenario", (event, callback) =>
+    @driver?.controlFlow().reset()
 
   @registerHandler "AfterFeatures", (event, callback) =>
     if shouldPreventBrowserReload()


### PR DESCRIPTION
If a step schedules a lot of driver commands, and an early one
fails, if the driver is retained (i.e. keep the same driver for
all scenarios) it will carry on with those scheduled commands
into the next scenario.

By flushing the command queue after each scenario, we ensure that
no 'old' commands are run in the wrong steps.