### PR TITLE
Fix tags arguments for the command line

### DIFF
--- a/src/config_builder.coffee
+++ b/src/config_builder.coffee
@@ -30,11 +30,15 @@ module.exports =
 
         switch
           when k is 'tags'
-            "--#{k}=".concat(
-              (_(Array::concat(val[k]))
-              .flatten()
-              .value())
-              .join(", "))
+            if typeof val[k] is 'string'
+              "--#{k}=".concat(
+                (_(Array::concat(val[k]))
+                .flatten()
+                .value())
+                .join(", "))
+            else
+              val[k].map (item, index) ->
+                "--#{k}=#{item}"
 
           when k is 'driver'
             process.argv.push "--driver=#{val[k]}"

--- a/test/unit/config.coffee
+++ b/test/unit/config.coffee
@@ -58,8 +58,12 @@ describe "Pioneer configuration", ->
         { 'preventReload': true }
       ]
 
-      this.multiTagConfig = [
+      this.multiTagConfigAndMode = [
         { tags: ["@wow", "@doge"]}
+      ]
+
+      this.multiTagConfigOrMode = [
+        { tags: ["@wow, @doge"]}
       ]
       scaffoldStub = sinon.stub(configBuilder, "hasFeature", -> true)
 
@@ -84,8 +88,13 @@ describe "Pioneer configuration", ->
       ])
       process.argv.should.eql(["--driver=phantomjs", "--prevent-browser-reload"])
 
+    it "should convertToExecOptions with multiple tags in AND mode", ->
+      configBuilder.convertToExecOptions(this.multiTagConfigAndMode, this.libPath)
+      .should.eql([null, null, "--require", "wow/support", "--tags=@wow", "--tags=@doge"])
+      process.argv.should.eql([])
+
     it "should convertToExecOptions with multiple tags", ->
-      configBuilder.convertToExecOptions(this.multiTagConfig, this.libPath)
+      configBuilder.convertToExecOptions(this.multiTagConfigOrMode, this.libPath)
       .should.eql([null, null, "--require", "wow/support", "--tags=@wow, @doge"])
       process.argv.should.eql([])
 


### PR DESCRIPTION
Based on https://github.com/cucumber/cucumber/wiki/Tags#logically-anding-and-oring-tags, if you executed:

```bash
node_modules/.bin/pioneer --tags=tagOne --tags=tagTwo
```

The tags were being ORed instead of ANDed.

The changes in this PR make the array of tags to be considered AND, and the string to be considered OR.

By the way, I tried executing like this:

```bash
node_modules/.bin/pioneer --tags=tagOne, tagTwo
```

But to properly be an argument, it should either be:

```bash
node_modules/.bin/pioneer --tags=tagOne,tagTwo
```
or

```bash
node_modules/.bin/pioneer --tags="tagOne, tagTwo"
```