### PR TITLE
Update scaffold for changes in the TodoMVC app

### DIFF
--- a/src/scaffold/simple.js
+++ b/src/scaffold/simple.js
@@ -5,13 +5,13 @@ module.exports = function(){
 
   this.When(/^I enter \"([^\"]*)\"$/, function(value){
     new this.Widget({
-      root: "#new-todo"
+      root: ".new-todo"
     }).sendKeys(value,'\uE007');
   });
 
   this.Then(/^I should see \"([^\"]*)\"$/, function(expected){
     var List = this.Widget.List.extend({
-      root: "#todo-list",
+      root: ".todo-list",
       childSelector: "li"
     })
 


### PR DESCRIPTION
It looks like the [TodoMVC example app](http://todomvc.com/examples/backbone/) that the example in the scaffold uses has changed so that these elements use ids instead of classes. 